### PR TITLE
Match chai AssertionError

### DIFF
--- a/compiler/mochajs.vim
+++ b/compiler/mochajs.vim
@@ -19,8 +19,7 @@ set cpo-=C
 CompilerSet makeprg=mocha
 CompilerSet errorformat=
             \%Enot\ ok\ %n%.%#,
-            \%Z\ %#at\ Context%.%#\ (%f:%l:%c),
-            \%Z\ %#at\ null%.%#\ (%f:%l:%c),
+            \%Z\ %#at\ %.%#\ (%f:%l:%c),
             \%C\ %#%m,
             \%-G1%.%#,
             \%-G\ %#at%.%#,


### PR DESCRIPTION
Chai assertion errors take the form
```
      at chai.request.post.send.end (test/test.js:35:21)
```
I've tweaked the `errorformat` to be a little fuzzier about matching `at... (location)` lines so that Chai errors are parsed correctly.

Thanks for making this 😄 